### PR TITLE
Add BUILD.gn configuration.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,157 @@
+# Copyright (C) 2018 Google, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#    Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+#    Neither the name of Google Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import("//build_overrides/glslang.gni")
+
+spirv_tools_dir = glslang_spirv_tools_dir
+
+config("glslang_public") {
+  include_dirs = [ "." ]
+}
+
+static_library("glslang_static") {
+  defines = []
+
+  public_configs = [ ":glslang_public" ]
+
+  sources = [
+    "OGLCompilersDLL/InitializeDll.cpp",
+    "OGLCompilersDLL/InitializeDll.h",
+    "SPIRV/GLSL.ext.EXT.h",
+    "SPIRV/GLSL.ext.KHR.h",
+    "SPIRV/GLSL.std.450.h",
+    "SPIRV/GlslangToSpv.cpp",
+    "SPIRV/GlslangToSpv.h",
+    "SPIRV/InReadableOrder.cpp",
+    "SPIRV/Logger.cpp",
+    "SPIRV/Logger.h",
+    "SPIRV/SPVRemapper.cpp",
+    "SPIRV/SPVRemapper.h",
+    "SPIRV/SpvBuilder.cpp",
+    "SPIRV/SpvBuilder.h",
+    "SPIRV/bitutils.h",
+    "SPIRV/disassemble.cpp",
+    "SPIRV/disassemble.h",
+    "SPIRV/doc.cpp",
+    "SPIRV/doc.h",
+    "SPIRV/hex_float.h",
+    "SPIRV/spirv.hpp",
+    "SPIRV/spvIR.h",
+    "glslang/GenericCodeGen/CodeGen.cpp",
+    "glslang/GenericCodeGen/Link.cpp",
+    "glslang/Include/BaseTypes.h",
+    "glslang/Include/Common.h",
+    "glslang/Include/ConstantUnion.h",
+    "glslang/Include/InfoSink.h",
+    "glslang/Include/InitializeGlobals.h",
+    "glslang/Include/PoolAlloc.h",
+    "glslang/Include/ResourceLimits.h",
+    "glslang/Include/ShHandle.h",
+    "glslang/Include/Types.h",
+    "glslang/Include/arrays.h",
+    "glslang/Include/intermediate.h",
+    "glslang/Include/revision.h",
+    "glslang/MachineIndependent/Constant.cpp",
+    "glslang/MachineIndependent/InfoSink.cpp",
+    "glslang/MachineIndependent/Initialize.cpp",
+    "glslang/MachineIndependent/Initialize.h",
+    "glslang/MachineIndependent/IntermTraverse.cpp",
+    "glslang/MachineIndependent/Intermediate.cpp",
+    "glslang/MachineIndependent/LiveTraverser.h",
+    "glslang/MachineIndependent/ParseContextBase.cpp",
+    "glslang/MachineIndependent/ParseHelper.cpp",
+    "glslang/MachineIndependent/ParseHelper.h",
+    "glslang/MachineIndependent/PoolAlloc.cpp",
+    "glslang/MachineIndependent/RemoveTree.cpp",
+    "glslang/MachineIndependent/RemoveTree.h",
+    "glslang/MachineIndependent/Scan.cpp",
+    "glslang/MachineIndependent/Scan.h",
+    "glslang/MachineIndependent/ScanContext.h",
+    "glslang/MachineIndependent/ShaderLang.cpp",
+    "glslang/MachineIndependent/SymbolTable.cpp",
+    "glslang/MachineIndependent/SymbolTable.h",
+    "glslang/MachineIndependent/Versions.cpp",
+    "glslang/MachineIndependent/Versions.h",
+    "glslang/MachineIndependent/attribute.cpp",
+    "glslang/MachineIndependent/attribute.h",
+    "glslang/MachineIndependent/gl_types.h",
+    "glslang/MachineIndependent/glslang.y",
+    "glslang/MachineIndependent/glslang_tab.cpp",
+    "glslang/MachineIndependent/glslang_tab.cpp.h",
+    "glslang/MachineIndependent/intermOut.cpp",
+    "glslang/MachineIndependent/iomapper.cpp",
+    "glslang/MachineIndependent/iomapper.h",
+    "glslang/MachineIndependent/limits.cpp",
+    "glslang/MachineIndependent/linkValidate.cpp",
+    "glslang/MachineIndependent/localintermediate.h",
+    "glslang/MachineIndependent/parseConst.cpp",
+    "glslang/MachineIndependent/parseVersions.h",
+    "glslang/MachineIndependent/preprocessor/Pp.cpp",
+    "glslang/MachineIndependent/preprocessor/PpAtom.cpp",
+    "glslang/MachineIndependent/preprocessor/PpContext.cpp",
+    "glslang/MachineIndependent/preprocessor/PpContext.h",
+    "glslang/MachineIndependent/preprocessor/PpScanner.cpp",
+    "glslang/MachineIndependent/preprocessor/PpTokens.cpp",
+    "glslang/MachineIndependent/preprocessor/PpTokens.h",
+    "glslang/MachineIndependent/propagateNoContraction.cpp",
+    "glslang/MachineIndependent/propagateNoContraction.h",
+    "glslang/MachineIndependent/reflection.cpp",
+    "glslang/MachineIndependent/reflection.h",
+    "glslang/OSDependent/osinclude.h",
+    "glslang/Public/ShaderLang.h",
+  ]
+
+  if (is_clang) {
+    cflags_cc = [
+      "-Wno-implicit-fallthrough",
+      "-Wno-ignored-qualifiers",
+      "-Wno-unused-variable",
+    ]
+  }
+
+  deps = [
+    "${spirv_tools_dir}:spvtools_opt",
+  ]
+
+  if (is_win) {
+    sources += [ "glslang/OSDependent/Windows/ossource.cpp" ]
+    defines += [ "GLSLANG_OSINCLUDE_WIN32" ]
+  } else {
+    sources += [ "glslang/OSDependent/Unix/ossource.cpp" ]
+    defines += [ "GLSLANG_OSINCLUDE_UNIX" ]
+  }
+
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+}
+

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -631,7 +631,7 @@ Id Builder::getContainedTypeId(Id typeId) const
 // Returns true if 'typeId' is or contains a scalar type declared with 'typeOp'
 // of width 'width'. The 'width' is only consumed for int and float types.
 // Returns false otherwise.
-bool Builder::containsType(Id typeId, spv::Op typeOp, int width) const
+bool Builder::containsType(Id typeId, spv::Op typeOp, uint32_t width) const
 {
     const Instruction& instr = *module.getInstruction(typeId);
 

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -172,7 +172,7 @@ public:
     bool isImageType(Id typeId)        const { return getTypeClass(typeId) == OpTypeImage; }
     bool isSamplerType(Id typeId)      const { return getTypeClass(typeId) == OpTypeSampler; }
     bool isSampledImageType(Id typeId) const { return getTypeClass(typeId) == OpTypeSampledImage; }
-    bool containsType(Id typeId, Op typeOp, int width) const;
+    bool containsType(Id typeId, Op typeOp, uint32_t width) const;
 
     bool isConstantOpCode(Op opcode) const;
     bool isSpecConstantOpCode(Op opcode) const;

--- a/build_overrides/glslang.gni
+++ b/build_overrides/glslang.gni
@@ -1,0 +1,37 @@
+# Copyright (C) 2018 Google, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#    Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+#    Neither the name of Google Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# These are variables that are overridable by projects that include glslang.
+
+# The path to glslang dependencies.
+glslang_spirv_tools_dir = "//Externals/spirv-tools"

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1560,6 +1560,8 @@ void TParseContext::memorySemanticsCheck(const TSourceLoc& loc, const TFunction&
         storageClassSemantics = (*argp)[1]->getAsConstantUnion()->getConstArray()[0].getIConst();
         semantics = (*argp)[2]->getAsConstantUnion()->getConstArray()[0].getIConst();
         break;
+    default:
+        break;
     }
 
     if ((semantics & gl_SemanticsAcquire) && 


### PR DESCRIPTION
This CL adds the necessary configuration to build glslang inside a
Chromium checkout. Two build warnings were fixed in the process to
make things compile.